### PR TITLE
Population Same Layer Bug Fix

### DIFF
--- a/BusinessLayer/Concrete/PopulateManager.cs
+++ b/BusinessLayer/Concrete/PopulateManager.cs
@@ -103,14 +103,14 @@ namespace BusinessLayer.Concrete
                 else
                 {
                     previousArtworkTemp = nextArtworkTemp;
-                    nextArtworkTemp = await MergeLayers(target,
-                                                  nextArtworkTemp,
-                                                  layers.ElementAt(layerIndex + 1),
-                                                  layerIndex + 1,
-                                                  layers,
-                                                  collection,
-                                                  artworkLayers,
-                                                  artworkTags);
+                    await MergeLayers(target,
+                                    nextArtworkTemp,
+                                    layers.ElementAt(layerIndex + 1),
+                                    layerIndex + 1,
+                                    layers,
+                                    collection,
+                                    artworkLayers,
+                                    artworkTags);
                 }
             }
             if (artworkLayers.Count != 0) artworkLayers.RemoveAt(artworkLayers.Count - 1);


### PR DESCRIPTION
We have the case where multiple images from same layer being drawn on top of each other.
There is a problem with the recursion.

![image](https://user-images.githubusercontent.com/19946639/170888036-4256b762-6abb-4c5b-b731-e6c7e5de3402.png)
_Note the double mustache._

- Removed `nextArtworkTemp` re-assignment inside the layer loop in `PopulateManager`